### PR TITLE
DataTables Buttons

### DIFF
--- a/jquery.dataTables/jquery.dataTables-tests.ts
+++ b/jquery.dataTables/jquery.dataTables-tests.ts
@@ -237,7 +237,7 @@ $(document).ready(function () {
                 },
                 {
                     action: function(e, dt, node, config){ },
-                    available: function(dt, config){ },
+                    available: function (dt, config) { return true;},
                     destroy: function(dt, node, config) { },
                     enabled: true,
                     init: function (dt, node, config) { },

--- a/jquery.dataTables/jquery.dataTables-tests.ts
+++ b/jquery.dataTables/jquery.dataTables-tests.ts
@@ -225,6 +225,28 @@ $(document).ready(function () {
             searchDelay: 10,
             stateDuration: 10,
             tabIndex: 10,
+            // Buttons extension options
+            buttons: [
+                {
+                    extend: 'excel',
+                    text: 'Excel',
+                    className: 'class',
+                    exportOptions: {
+                        columns: ':visible'
+                    }
+                },
+                {
+                    action: function(e, dt, node, config){ },
+                    available: function(dt, config){ },
+                    destroy: function(dt, node, config) { },
+                    enabled: true,
+                    init: function (dt, node, config) { },
+                    key: 'a',
+                    name: 'name',
+                    namespace: 'namespace',
+                    titleAttr: 'title',
+                }
+            ],
         };
 
 

--- a/jquery.dataTables/jquery.dataTables.d.ts
+++ b/jquery.dataTables/jquery.dataTables.d.ts
@@ -1143,6 +1143,11 @@ declare module DataTables {
         //#region "Options"
 
         /**
+        * Buttons extension options
+        */
+        buttons?: boolean | string[] | ButtonSettings[];
+
+        /**
         * Data to use as the display data for the table. Since: 1.10
         */
         columns?: ColumnSettings[];
@@ -1400,7 +1405,104 @@ declare module DataTables {
 
     //#endregion "ajax-settings"
 
-    //#region "colunm-settings"
+    //#region "button-settings"
+    
+    /**
+    * Buttons extension options
+    */
+    export interface ButtonSettings {
+        /**
+        * Action to take when the button is activated
+        */
+        action?: FunctionButtonAction;
+
+        /**
+        * Ensure that any requirements have been satisfied before initialising a button
+        */
+        available?: FunctionButtonAvailable;
+
+        /**
+        * Set the class name for the button
+        */
+        className?: string;
+
+        /**
+        * Function that is called when the button is destroyed
+        */
+        destroy?: FunctionButtonInit;
+
+        /**
+        * Set a button's initial enabled state
+        */
+        enabled?: boolean;
+
+        /**
+        * Define which button type the button should be based on
+        */
+        extend?: string;
+
+        /**
+        * Initialisation function that can be used to add events specific to this button
+        */
+        init?: FunctionButtonInit;
+
+        /**
+        * Define an activation key for a button
+        */
+        key?: string | ButtonKey;
+
+        /**
+        * Set a name for each selection
+        */
+        name?: string;
+
+        /**
+        * Unique namespace for every button
+        */
+        namespace?: string;
+
+        /**
+        * The text to show in the button
+        */
+        text?: string | ButtonText;
+
+        /**
+        * Button 'title' attribute text
+        */
+        titleAttr?: string;
+
+        exportOptions?: ButtonExportOptions;
+        autoPrint?: boolean;
+    }
+
+    export interface FunctionButtonAvailable {
+        (dt: DataTables.DataTable, config: any): boolean
+    }
+    export interface ButtonExportOptions {
+        columns?: string;
+    }
+
+    export interface ButtonKey {
+        key?: string;
+        shiftKey?: boolean;
+        altKey?: boolean;
+        ctrlKey?: boolean;
+        metaKey?: boolean;
+    }
+
+    export interface ButtonText {
+        (dt: DataTables.DataTable, node: JQuery, config: any): string
+    }
+    export interface FunctionButtonInit {
+        (dt: DataTables.DataTable, node: JQuery, config: any): void
+    }
+    // api object?
+    export interface FunctionButtonAction {
+        (e: any, dt: DataTables.DataTable, node: JQuery, config: any): void
+    }
+    //#endregion "button-settings
+
+    //#region "column-settings"
 
     export interface ColumnSettings {
         /**
@@ -1724,7 +1826,7 @@ declare module DataTables {
         _iRecordsDisplay: number;
         bJUI: boolean;
         oClasses: any;
-        bFiltered: boolean;
+        bFilter: boolean;
         bSorted: boolean;
         bSortCellsTop: boolean;
         oInit: any;


### PR DESCRIPTION
Added DataTables Buttons extension types into existing jquery.dataTables.d.ts, and added test code.
